### PR TITLE
typo on class name from MainMatedata to MainMetadata

### DIFF
--- a/samples/com/autodesk/samples/MainMetadata.java
+++ b/samples/com/autodesk/samples/MainMetadata.java
@@ -24,7 +24,7 @@ import java.util.List;
 //simple test without much error checking
 //check the first guid of the metadata only
 
-public class MainMatedata {
+public class MainMetadata {
 
     //TODO - insert your CLIENT_ID and CLIENT_SECRET
     private static final String CLIENT_ID = "<your client id>";


### PR DESCRIPTION
Debugging came across a typo on the class. Fixed and debugging goes through without the error. 