### PR TITLE
ObjectDetails & ObjectFullDetails size parameter changed to Long

### DIFF
--- a/src/main/java/com/autodesk/client/model/ObjectDetails.java
+++ b/src/main/java/com/autodesk/client/model/ObjectDetails.java
@@ -52,7 +52,7 @@ public class ObjectDetails   {
   private byte[] sha1 = null;
 
   @JsonProperty("size")
-  private Integer size = null;
+  private Long size = null;
 
   @JsonProperty("contentType")
   private String contentType = null;
@@ -132,7 +132,7 @@ public class ObjectDetails   {
     this.sha1 = sha1;
   }
 
-  public ObjectDetails size(Integer size) {
+  public ObjectDetails size(Long size) {
     this.size = size;
     return this;
   }
@@ -142,11 +142,11 @@ public class ObjectDetails   {
    * @return size
   **/
   @ApiModelProperty(example = "null", value = "Object size")
-  public Integer getSize() {
+  public Long getSize() {
     return size;
   }
 
-  public void setSize(Integer size) {
+  public void setSize(Long size) {
     this.size = size;
   }
 

--- a/src/main/java/com/autodesk/client/model/ObjectFullDetails.java
+++ b/src/main/java/com/autodesk/client/model/ObjectFullDetails.java
@@ -55,7 +55,7 @@ public class ObjectFullDetails   {
   private byte[] sha1 = null;
 
   @JsonProperty("size")
-  private Integer size = null;
+  private Long size = null;
 
   @JsonProperty("contentType")
   private String contentType = null;
@@ -141,7 +141,7 @@ public class ObjectFullDetails   {
     this.sha1 = sha1;
   }
 
-  public ObjectFullDetails size(Integer size) {
+  public ObjectFullDetails size(Long size) {
     this.size = size;
     return this;
   }
@@ -151,11 +151,11 @@ public class ObjectFullDetails   {
    * @return size
   **/
   @ApiModelProperty(example = "null", value = "Object size")
-  public Integer getSize() {
+  public Long getSize() {
     return size;
   }
 
-  public void setSize(Integer size) {
+  public void setSize(Long size) {
     this.size = size;
   }
 


### PR DESCRIPTION
encountered an exception while uploading 4GB+ file using uploadChunk.

> com.sun.jersey.api.client.ClientHandlerException: com.fasterxml.jackson.databind.JsonMappingException: Numeric value (4053603613) out of range of int
>  at [Source: (sun.net.www.protocol.http.HttpURLConnection$HttpInputStream); line: 5, column: 22]
>  at [Source: (sun.net.www.protocol.http.HttpURLConnection$HttpInputStream); line: 5, column: 12] (through reference chain: com.autodesk.client.model.ObjectDetails["size"])
> at com.sun.jersey.api.client.ClientResponse.getEntity(ClientResponse.java:644)
> at com.sun.jersey.api.client.ClientResponse.getEntity(ClientResponse.java:604)
> at com.autodesk.client.ApiClient.invokeAPI(ApiClient.java:562)
> at com.autodesk.client.api.ObjectsApi.uploadChunk(ObjectsApi.java:628)

Changed the size parameter "size" type to Long to solve it.