### PR TITLE
Error "ForceGet" paramametter in method "getModelviewProperties"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 target
 *.iml
 .DS_Store
+
+.classpath
+.project
+.settings/
+.project
+.settings

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the following dependency to your `pom.xml`:
 <dependency>
    	<groupId>com.autodesk</groupId>
    	<artifactId>forge-java-sdk</artifactId>
-   	<version>1.0.1</version>
+   	<version>1.0.2</version>
 </dependency>
 ```
 
@@ -43,7 +43,7 @@ repositories {
     mavenLocal()
 }
 dependencies {
-    compile "com.autodesk:forge-java-sdk:1.0.1"
+    compile "com.autodesk:forge-java-sdk:1.0.2"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add the following dependency to your `pom.xml`:
 ```xml
 <dependency>
    	<groupId>com.autodesk</groupId>
-   	<artifactId>forge-java-sdk</artifactId>
+   	<artifactId>com-autodesk-client</artifactId>
    	<version>1.0.2</version>
 </dependency>
 ```
@@ -43,7 +43,7 @@ repositories {
     mavenLocal()
 }
 dependencies {
-    compile "com.autodesk:forge-java-sdk:1.0.2"
+    compile "com.autodesk:com-autodesk-client:1.0.2"
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>com-autodesk-client</artifactId>
   <packaging>jar</packaging>
   <name>com-autodesk-client</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
 
   <prerequisites>
     <maven>2.2.0</maven>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.autodesk</groupId>
-  <artifactId>com-autodesk-client</artifactId>
+  <artifactId>forge-java-sdk</artifactId>
   <packaging>jar</packaging>
   <name>com-autodesk-client</name>
   <version>1.0.2</version>

--- a/src/main/java/com/autodesk/client/StringUtil.java
+++ b/src/main/java/com/autodesk/client/StringUtil.java
@@ -25,6 +25,15 @@
 
 package com.autodesk.client;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
 
 public class StringUtil {
   /**
@@ -64,4 +73,48 @@ public class StringUtil {
     }
     return out.toString();
   }
+
+	public static class JacksonMapper {
+
+		private static final ObjectMapper mapper = new ObjectMapper();
+
+		private static final JacksonMapper INSTANCE;
+
+		static {
+			INSTANCE = new JacksonMapper();
+		}
+
+		private JacksonMapper() {
+			// not called
+		}
+
+		public static JacksonMapper getInstance() {
+
+			return INSTANCE;
+		}
+
+		public Map<String, String> toMap(String jsonString) throws Exception {
+
+			return mapper.readValue(jsonString, new TypeReference<HashMap<String, String>>() {
+			});
+
+		}
+		/**
+		 * Convert JSON to {@link List} {@link Pair}
+		 * @param jsonString
+		 * @return
+		 * @throws Exception
+		 */
+		public List<Pair> toListPair(String jsonString) throws Exception {
+			List<Pair> list = new ArrayList<>();
+			Map<String, String> map = toMap(jsonString);
+			for (Map.Entry<String, String> entry : map.entrySet())
+			{
+				list.add(new Pair(entry.getKey(), entry.getValue()));
+			}
+			return list;
+		}
+		
+	}
 }
+

--- a/src/main/java/com/autodesk/client/api/DerivativesApi.java
+++ b/src/main/java/com/autodesk/client/api/DerivativesApi.java
@@ -24,336 +24,387 @@
 
 package com.autodesk.client.api;
 
-import com.sun.jersey.api.client.GenericType;
-
-import com.autodesk.client.ApiException;
-import com.autodesk.client.ApiClient;
-import com.autodesk.client.Configuration;
-import com.autodesk.client.model.*;
-import com.autodesk.client.Pair;
-import com.autodesk.client.auth.Credentials;
-import com.autodesk.client.auth.Authentication;
-import com.autodesk.client.ApiResponse;
-
 import java.io.File;
-
-import com.autodesk.client.model.Diagnostics;
-import com.autodesk.client.model.Result;
-import com.autodesk.client.model.Formats;
-import java.util.Date;
-import com.autodesk.client.model.Manifest;
-import com.autodesk.client.model.Metadata;
-import java.io.File;
-import com.autodesk.client.model.Job;
-import com.autodesk.client.model.JobPayload;
-
-
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.autodesk.client.ApiClient;
+import com.autodesk.client.ApiException;
+import com.autodesk.client.ApiResponse;
+import com.autodesk.client.Configuration;
+import com.autodesk.client.Pair;
+import com.autodesk.client.StringUtil.JacksonMapper;
+import com.autodesk.client.auth.Authentication;
+import com.autodesk.client.auth.Credentials;
+import com.autodesk.client.model.Formats;
+import com.autodesk.client.model.Job;
+import com.autodesk.client.model.JobPayload;
+import com.autodesk.client.model.Manifest;
+import com.autodesk.client.model.Metadata;
+import com.autodesk.client.model.Result;
+import com.sun.jersey.api.client.GenericType;
 
 public class DerivativesApi {
-  private ApiClient apiClient;
+	private ApiClient apiClient;
 
-  public DerivativesApi() {
-    this(Configuration.getDefaultApiClient());
-  }
+	public DerivativesApi() {
+		this(Configuration.getDefaultApiClient());
+	}
 
-  public DerivativesApi(ApiClient apiClient) {
-    this.apiClient = apiClient;
-  }
+	public DerivativesApi(ApiClient apiClient) {
+		this.apiClient = apiClient;
+	}
 
-  public ApiClient getApiClient() {
-    return apiClient;
-  }
+	public ApiClient getApiClient() {
+		return apiClient;
+	}
 
-  public void setApiClient(ApiClient apiClient) {
-    this.apiClient = apiClient;
-  }
+	public void setApiClient(ApiClient apiClient) {
+		this.apiClient = apiClient;
+	}
 
-  /**
-   * 
-   * Deletes the manifest and all its translated output files (derivatives). However, it does not delete the design source file. 
-   * @param urn The Base64 (URL Safe) encoded design URN  (required)
-   * @return Result
-   * @throws ApiException if fails to make API call
-   */
-  public ApiResponse<Result> deleteManifest(String urn,  Authentication oauth2, Credentials credentials) throws ApiException, Exception {
+	/**
+	 * 
+	 * Deletes the manifest and all its translated output files (derivatives).
+	 * However, it does not delete the design source file.
+	 * 
+	 * @param urn The Base64 (URL Safe) encoded design URN (required)
+	 * @return Result
+	 * @throws ApiException if fails to make API call
+	 */
+	public ApiResponse<Result> deleteManifest(String urn, Authentication oauth2, Credentials credentials)
+			throws ApiException, Exception {
 
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'urn' is set
-    if (urn == null) {
-      throw new ApiException(400, "Missing the required parameter 'urn' when calling deleteManifest");
-    }
-    
-    // create path and map variables
-    String localVarPath = "/modelderivative/v2/designdata/{urn}/manifest".replaceAll("\\{format\\}","json")
-      .replaceAll("\\{" + "urn" + "\\}", apiClient.escapeString(urn.toString()));
+		Object localVarPostBody = null;
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+		// verify the required parameter 'urn' is set
+		if (urn == null) {
+			throw new ApiException(400, "Missing the required parameter 'urn' when calling deleteManifest");
+		}
 
+		// create path and map variables
+		String localVarPath = "/modelderivative/v2/designdata/{urn}/manifest".replaceAll("\\{format\\}", "json")
+				.replaceAll("\\{" + "urn" + "\\}", apiClient.escapeString(urn.toString()));
 
-    
-    
-    final String[] localVarAccepts = {
-      "application/vnd.api+json", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+		// query params
+		List<Pair> localVarQueryParams = new ArrayList<Pair>();
+		Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+		Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
-    final String[] localVarContentTypes = {
-      "application/x-www-form-urlencoded"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+		final String[] localVarAccepts = { "application/vnd.api+json", "application/json" };
+		final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
-    GenericType<Result> localVarReturnType = new GenericType<Result>() {};
-    return apiClient.invokeAPI(oauth2, credentials, localVarPath, "DELETE", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
-      }
-  /**
-   * 
-   * Downloads a selected derivative. To download the file, you need to specify the file’s URN, which you retrieve by calling the [GET {urn}/manifest](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-manifest-GET) endpoint.  Note that the Model Derivative API uses 2 types of URNs. The **design URN** is generated when you upload the source design file to Forge, and is used when calling most of the Model Derivative endpoints. A **derivative URN** is generated for each translated output file format, and is used for downloading the output design files.  You can set the range of bytes that are returned when downloading the derivative, using the range header. 
-   * @param urn The Base64 (URL Safe) encoded design URN  (required)
-   * @param derivativeUrn The URL-encoded URN of the derivatives. The URN is retrieved from the GET :urn/manifest endpoint.  (required)
-   * @param range This is the standard RFC 2616 range request header. It only supports one range specifier per request: 1. Range:bytes&#x3D;0-63 (returns the first 64 bytes) 2. Range:bytes&#x3D;64-127 (returns the second set of 64 bytes) 3. Range:bytes&#x3D;1022- (returns all the bytes from offset 1022 to the end) 4. If the range header is not specified, the whole content is returned.  (optional)
-   * @throws ApiException if fails to make API call
-   */
-  public ApiResponse<Void> getDerivativeManifest(String urn, String derivativeUrn, Integer range,  Authentication oauth2, Credentials credentials) throws ApiException, Exception {
+		final String[] localVarContentTypes = { "application/x-www-form-urlencoded" };
+		final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'urn' is set
-    if (urn == null) {
-      throw new ApiException(400, "Missing the required parameter 'urn' when calling getDerivativeManifest");
-    }
-    
-    // verify the required parameter 'derivativeUrn' is set
-    if (derivativeUrn == null) {
-      throw new ApiException(400, "Missing the required parameter 'derivativeUrn' when calling getDerivativeManifest");
-    }
-    
-    // create path and map variables
-    String localVarPath = "/modelderivative/v2/designdata/{urn}/manifest/{derivativeUrn}".replaceAll("\\{format\\}","json")
-      .replaceAll("\\{" + "urn" + "\\}", apiClient.escapeString(urn.toString()))
-      .replaceAll("\\{" + "derivativeUrn" + "\\}", apiClient.escapeString(derivativeUrn.toString()));
+		GenericType<Result> localVarReturnType = new GenericType<Result>() {
+		};
+		return apiClient.invokeAPI(oauth2, credentials, localVarPath, "DELETE", localVarQueryParams, localVarPostBody,
+				localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
+	}
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+	/**
+	 * 
+	 * Downloads a selected derivative. To download the file, you need to specify
+	 * the file’s URN, which you retrieve by calling the [GET
+	 * {urn}/manifest](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-manifest-GET)
+	 * endpoint. Note that the Model Derivative API uses 2 types of URNs. The
+	 * **design URN** is generated when you upload the source design file to Forge,
+	 * and is used when calling most of the Model Derivative endpoints. A
+	 * **derivative URN** is generated for each translated output file format, and
+	 * is used for downloading the output design files. You can set the range of
+	 * bytes that are returned when downloading the derivative, using the range
+	 * header.
+	 * 
+	 * @param urn           The Base64 (URL Safe) encoded design URN (required)
+	 * @param derivativeUrn The URL-encoded URN of the derivatives. The URN is
+	 *                      retrieved from the GET :urn/manifest endpoint.
+	 *                      (required)
+	 * @param range         This is the standard RFC 2616 range request header. It
+	 *                      only supports one range specifier per request: 1.
+	 *                      Range:bytes&#x3D;0-63 (returns the first 64 bytes) 2.
+	 *                      Range:bytes&#x3D;64-127 (returns the second set of 64
+	 *                      bytes) 3. Range:bytes&#x3D;1022- (returns all the bytes
+	 *                      from offset 1022 to the end) 4. If the range header is
+	 *                      not specified, the whole content is returned. (optional)
+	 * @throws ApiException if fails to make API call
+	 */
+	public ApiResponse<Void> getDerivativeManifest(String urn, String derivativeUrn, Integer range,
+			Authentication oauth2, Credentials credentials) throws ApiException, Exception {
 
+		Object localVarPostBody = null;
 
-    if (range != null)
-      localVarHeaderParams.put("Range", apiClient.parameterToString(range));
+		// verify the required parameter 'urn' is set
+		if (urn == null) {
+			throw new ApiException(400, "Missing the required parameter 'urn' when calling getDerivativeManifest");
+		}
 
-    
-    final String[] localVarAccepts = {
-      "application/octet-stream"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+		// verify the required parameter 'derivativeUrn' is set
+		if (derivativeUrn == null) {
+			throw new ApiException(400,
+					"Missing the required parameter 'derivativeUrn' when calling getDerivativeManifest");
+		}
 
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+		// create path and map variables
+		String localVarPath = "/modelderivative/v2/designdata/{urn}/manifest/{derivativeUrn}"
+				.replaceAll("\\{format\\}", "json")
+				.replaceAll("\\{" + "urn" + "\\}", apiClient.escapeString(urn.toString()))
+				.replaceAll("\\{" + "derivativeUrn" + "\\}", apiClient.escapeString(derivativeUrn.toString()));
 
+		// query params
+		List<Pair> localVarQueryParams = new ArrayList<Pair>();
+		Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+		Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
-    return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, null);
-  }
-  /**
-   * 
-   * Returns an up-to-date list of Forge-supported translations, that you can use to identify which types of derivatives are supported for each source file type. You can set this endpoint to only return the list of supported translations if they have been updated since a specified date.  See the [Supported Translation Formats table](https://developer.autodesk.com/en/docs/model-derivative/v2/overview/supported-translations) for more details about supported translations.  Note that we are constantly adding new file formats to the list of Forge translations. 
-   * @param ifModifiedSince The supported formats are only returned if they were modified since the specified date. An invalid date returns the latest supported format list. If the supported formats have not been modified since the specified date, the endpoint returns a &#x60;NOT MODIFIED&#x60; (304) response.  (optional)
-   * @param acceptEncoding If specified with &#x60;gzip&#x60; or &#x60;*&#x60;, content will be compressed and returned in a GZIP format.  (optional)
-   * @return Formats
-   * @throws ApiException if fails to make API call
-   */
-  public ApiResponse<Formats> getFormats(Date ifModifiedSince, String acceptEncoding,  Authentication oauth2, Credentials credentials) throws ApiException, Exception {
+		if (range != null)
+			localVarHeaderParams.put("Range", apiClient.parameterToString(range));
 
-    Object localVarPostBody = null;
-    
-    // create path and map variables
-    String localVarPath = "/modelderivative/v2/designdata/formats".replaceAll("\\{format\\}","json");
+		final String[] localVarAccepts = { "application/octet-stream" };
+		final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+		final String[] localVarContentTypes = { "application/json" };
+		final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
+		return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody,
+				localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, null);
+	}
 
-    if (ifModifiedSince != null)
-      localVarHeaderParams.put("If-Modified-Since", apiClient.parameterToString(ifModifiedSince));
-if (acceptEncoding != null)
-      localVarHeaderParams.put("Accept-Encoding", apiClient.parameterToString(acceptEncoding));
+	/**
+	 * 
+	 * Returns an up-to-date list of Forge-supported translations, that you can use
+	 * to identify which types of derivatives are supported for each source file
+	 * type. You can set this endpoint to only return the list of supported
+	 * translations if they have been updated since a specified date. See the
+	 * [Supported Translation Formats
+	 * table](https://developer.autodesk.com/en/docs/model-derivative/v2/overview/supported-translations)
+	 * for more details about supported translations. Note that we are constantly
+	 * adding new file formats to the list of Forge translations.
+	 * 
+	 * @param ifModifiedSince The supported formats are only returned if they were
+	 *                        modified since the specified date. An invalid date
+	 *                        returns the latest supported format list. If the
+	 *                        supported formats have not been modified since the
+	 *                        specified date, the endpoint returns a &#x60;NOT
+	 *                        MODIFIED&#x60; (304) response. (optional)
+	 * @param acceptEncoding  If specified with &#x60;gzip&#x60; or &#x60;*&#x60;,
+	 *                        content will be compressed and returned in a GZIP
+	 *                        format. (optional)
+	 * @return Formats
+	 * @throws ApiException if fails to make API call
+	 */
+	public ApiResponse<Formats> getFormats(Date ifModifiedSince, String acceptEncoding, Authentication oauth2,
+			Credentials credentials) throws ApiException, Exception {
 
-    
-    final String[] localVarAccepts = {
-      "application/vnd.api+json", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+		Object localVarPostBody = null;
 
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+		// create path and map variables
+		String localVarPath = "/modelderivative/v2/designdata/formats".replaceAll("\\{format\\}", "json");
 
-    GenericType<Formats> localVarReturnType = new GenericType<Formats>() {};
-    return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
-      }
-  /**
-   * 
-   * Returns information about derivatives that correspond to a specific source file, including derviative URNs and statuses.  The URNs of the derivatives are used to download the generated derivatives when calling the [GET {urn}/manifest/{derivativeurn}](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-manifest-derivativeurn-GET) endpoint.  The statuses are used to verify whether the translation of requested output files is complete.  Note that different output files might complete their translation processes at different times, and therefore may have different &#x60;status&#x60; values.  When translating a source file a second time, the previously created manifest is not deleted; it appends the information (only new translations) to the manifest. 
-   * @param urn The Base64 (URL Safe) encoded design URN  (required)
-   * @param acceptEncoding If specified with &#x60;gzip&#x60; or &#x60;*&#x60;, content will be compressed and returned in a GZIP format.  (optional)
-   * @return Manifest
-   * @throws ApiException if fails to make API call
-   */
-  public ApiResponse<Manifest> getManifest(String urn, String acceptEncoding,  Authentication oauth2, Credentials credentials) throws ApiException, Exception {
+		// query params
+		List<Pair> localVarQueryParams = new ArrayList<Pair>();
+		Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+		Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'urn' is set
-    if (urn == null) {
-      throw new ApiException(400, "Missing the required parameter 'urn' when calling getManifest");
-    }
-    
-    // create path and map variables
-    String localVarPath = "/modelderivative/v2/designdata/{urn}/manifest".replaceAll("\\{format\\}","json")
-      .replaceAll("\\{" + "urn" + "\\}", apiClient.escapeString(urn.toString()));
+		if (ifModifiedSince != null)
+			localVarHeaderParams.put("If-Modified-Since", apiClient.parameterToString(ifModifiedSince));
+		if (acceptEncoding != null)
+			localVarHeaderParams.put("Accept-Encoding", apiClient.parameterToString(acceptEncoding));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+		final String[] localVarAccepts = { "application/vnd.api+json", "application/json" };
+		final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
+		final String[] localVarContentTypes = { "application/json" };
+		final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
-    if (acceptEncoding != null)
-      localVarHeaderParams.put("Accept-Encoding", apiClient.parameterToString(acceptEncoding));
+		GenericType<Formats> localVarReturnType = new GenericType<Formats>() {
+		};
+		return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody,
+				localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
+	}
 
-    
-    final String[] localVarAccepts = {
-      "application/vnd.api+json", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+	/**
+	 * 
+	 * Returns information about derivatives that correspond to a specific source
+	 * file, including derviative URNs and statuses. The URNs of the derivatives are
+	 * used to download the generated derivatives when calling the [GET
+	 * {urn}/manifest/{derivativeurn}](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-manifest-derivativeurn-GET)
+	 * endpoint. The statuses are used to verify whether the translation of
+	 * requested output files is complete. Note that different output files might
+	 * complete their translation processes at different times, and therefore may
+	 * have different &#x60;status&#x60; values. When translating a source file a
+	 * second time, the previously created manifest is not deleted; it appends the
+	 * information (only new translations) to the manifest.
+	 * 
+	 * @param urn            The Base64 (URL Safe) encoded design URN (required)
+	 * @param acceptEncoding If specified with &#x60;gzip&#x60; or &#x60;*&#x60;,
+	 *                       content will be compressed and returned in a GZIP
+	 *                       format. (optional)
+	 * @return Manifest
+	 * @throws ApiException if fails to make API call
+	 */
+	public ApiResponse<Manifest> getManifest(String urn, String acceptEncoding, Authentication oauth2,
+			Credentials credentials) throws ApiException, Exception {
 
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+		Object localVarPostBody = null;
 
-    GenericType<Manifest> localVarReturnType = new GenericType<Manifest>() {};
-    return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
-      }
-  /**
-   * 
-   * Returns a list of model view (metadata) IDs for a design model. The metadata ID enables end users to select an object tree and properties for a specific model view.  Although most design apps (e.g., Fusion and Inventor) only allow a single model view (object tree and set of properties), some apps (e.g., Revit) allow users to design models with multiple model views (e.g., HVAC, architecture, perspective).  Note that you can only retrieve metadata from an input file that has been translated into an SVF file. 
-   * @param urn The Base64 (URL Safe) encoded design URN  (required)
-   * @param acceptEncoding If specified with &#x60;gzip&#x60; or &#x60;*&#x60;, content will be compressed and returned in a GZIP format.  (optional)
-   * @return Metadata
-   * @throws ApiException if fails to make API call
-   */
-  public ApiResponse<Metadata> getMetadata(String urn, String acceptEncoding,  Authentication oauth2, Credentials credentials) throws ApiException, Exception {
+		// verify the required parameter 'urn' is set
+		if (urn == null) {
+			throw new ApiException(400, "Missing the required parameter 'urn' when calling getManifest");
+		}
 
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'urn' is set
-    if (urn == null) {
-      throw new ApiException(400, "Missing the required parameter 'urn' when calling getMetadata");
-    }
-    
-    // create path and map variables
-    String localVarPath = "/modelderivative/v2/designdata/{urn}/metadata".replaceAll("\\{format\\}","json")
-      .replaceAll("\\{" + "urn" + "\\}", apiClient.escapeString(urn.toString()));
+		// create path and map variables
+		String localVarPath = "/modelderivative/v2/designdata/{urn}/manifest".replaceAll("\\{format\\}", "json")
+				.replaceAll("\\{" + "urn" + "\\}", apiClient.escapeString(urn.toString()));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+		// query params
+		List<Pair> localVarQueryParams = new ArrayList<Pair>();
+		Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+		Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
+		if (acceptEncoding != null)
+			localVarHeaderParams.put("Accept-Encoding", apiClient.parameterToString(acceptEncoding));
 
-    if (acceptEncoding != null)
-      localVarHeaderParams.put("Accept-Encoding", apiClient.parameterToString(acceptEncoding));
+		final String[] localVarAccepts = { "application/vnd.api+json", "application/json" };
+		final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
-    
-    final String[] localVarAccepts = {
-      "application/vnd.api+json", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+		final String[] localVarContentTypes = { "application/json" };
+		final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+		GenericType<Manifest> localVarReturnType = new GenericType<Manifest>() {
+		};
+		return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody,
+				localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
+	}
 
-    GenericType<Metadata> localVarReturnType = new GenericType<Metadata>() {};
-    return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
-      }
-  /**
-   * 
-   * Returns an object tree, i.e., a hierarchical list of objects for a model view.  To call this endpoint you first need to call the [GET {urn}/metadata](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-metadata-GET) endpoint, to determine which model view (object tree and set of properties) to use.  Although most design apps (e.g., Fusion and Inventor) only allow a single model view, some apps (e.g., Revit) allow users to design models with multiple model views (e.g., HVAC, architecture, perspective).  Note that you can only retrieve metadata from an input file that has been translated into an SVF file. 
-   * @param urn The Base64 (URL Safe) encoded design URN  (required)
-   * @param guid Unique model view ID. Call [GET {urn}/metadata](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-metadata-GET) to get the ID  (required)
-   * @param acceptEncoding If specified with &#x60;gzip&#x60; or &#x60;*&#x60;, content will be compressed and returned in a GZIP format.  (optional)
-   * @return Metadata
-   * @throws ApiException if fails to make API call
-   */
-  public ApiResponse<Metadata> getModelviewMetadata(String urn, String guid, String acceptEncoding,  Authentication oauth2, Credentials credentials) throws ApiException, Exception {
+	/**
+	 * 
+	 * Returns a list of model view (metadata) IDs for a design model. The metadata
+	 * ID enables end users to select an object tree and properties for a specific
+	 * model view. Although most design apps (e.g., Fusion and Inventor) only allow
+	 * a single model view (object tree and set of properties), some apps (e.g.,
+	 * Revit) allow users to design models with multiple model views (e.g., HVAC,
+	 * architecture, perspective). Note that you can only retrieve metadata from an
+	 * input file that has been translated into an SVF file.
+	 * 
+	 * @param urn            The Base64 (URL Safe) encoded design URN (required)
+	 * @param acceptEncoding If specified with &#x60;gzip&#x60; or &#x60;*&#x60;,
+	 *                       content will be compressed and returned in a GZIP
+	 *                       format. (optional)
+	 * @return Metadata
+	 * @throws ApiException if fails to make API call
+	 */
+	public ApiResponse<Metadata> getMetadata(String urn, String acceptEncoding, Authentication oauth2,
+			Credentials credentials) throws ApiException, Exception {
 
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'urn' is set
-    if (urn == null) {
-      throw new ApiException(400, "Missing the required parameter 'urn' when calling getModelviewMetadata");
-    }
-    
-    // verify the required parameter 'guid' is set
-    if (guid == null) {
-      throw new ApiException(400, "Missing the required parameter 'guid' when calling getModelviewMetadata");
-    }
-    
-    // create path and map variables
-    String localVarPath = "/modelderivative/v2/designdata/{urn}/metadata/{guid}".replaceAll("\\{format\\}","json")
-      .replaceAll("\\{" + "urn" + "\\}", apiClient.escapeString(urn.toString()))
-      .replaceAll("\\{" + "guid" + "\\}", apiClient.escapeString(guid.toString()));
+		Object localVarPostBody = null;
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+		// verify the required parameter 'urn' is set
+		if (urn == null) {
+			throw new ApiException(400, "Missing the required parameter 'urn' when calling getMetadata");
+		}
 
+		// create path and map variables
+		String localVarPath = "/modelderivative/v2/designdata/{urn}/metadata".replaceAll("\\{format\\}", "json")
+				.replaceAll("\\{" + "urn" + "\\}", apiClient.escapeString(urn.toString()));
 
-    if (acceptEncoding != null)
-      localVarHeaderParams.put("Accept-Encoding", apiClient.parameterToString(acceptEncoding));
+		// query params
+		List<Pair> localVarQueryParams = new ArrayList<Pair>();
+		Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+		Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
-    
-    final String[] localVarAccepts = {
-      "application/vnd.api+json", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+		if (acceptEncoding != null)
+			localVarHeaderParams.put("Accept-Encoding", apiClient.parameterToString(acceptEncoding));
 
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+		final String[] localVarAccepts = { "application/vnd.api+json", "application/json" };
+		final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
-    GenericType<Metadata> localVarReturnType = new GenericType<Metadata>() {};
-    return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
-      }
-  /**
-   * 
+		final String[] localVarContentTypes = { "application/json" };
+		final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+		GenericType<Metadata> localVarReturnType = new GenericType<Metadata>() {
+		};
+		return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody,
+				localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
+	}
+
+	/**
+	 * 
+	 * Returns an object tree, i.e., a hierarchical list of objects for a model
+	 * view. To call this endpoint you first need to call the [GET
+	 * {urn}/metadata](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-metadata-GET)
+	 * endpoint, to determine which model view (object tree and set of properties)
+	 * to use. Although most design apps (e.g., Fusion and Inventor) only allow a
+	 * single model view, some apps (e.g., Revit) allow users to design models with
+	 * multiple model views (e.g., HVAC, architecture, perspective). Note that you
+	 * can only retrieve metadata from an input file that has been translated into
+	 * an SVF file.
+	 * 
+	 * @param urn            The Base64 (URL Safe) encoded design URN (required)
+	 * @param guid           Unique model view ID. Call [GET
+	 *                       {urn}/metadata](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-metadata-GET)
+	 *                       to get the ID (required)
+	 * @param acceptEncoding If specified with &#x60;gzip&#x60; or &#x60;*&#x60;,
+	 *                       content will be compressed and returned in a GZIP
+	 *                       format. (optional)
+	 * @return Metadata
+	 * @throws ApiException if fails to make API call
+	 */
+	public ApiResponse<Metadata> getModelviewMetadata(String urn, String guid, String acceptEncoding,
+			Authentication oauth2, Credentials credentials) throws ApiException, Exception {
+
+		Object localVarPostBody = null;
+
+		// verify the required parameter 'urn' is set
+		if (urn == null) {
+			throw new ApiException(400, "Missing the required parameter 'urn' when calling getModelviewMetadata");
+		}
+
+		// verify the required parameter 'guid' is set
+		if (guid == null) {
+			throw new ApiException(400, "Missing the required parameter 'guid' when calling getModelviewMetadata");
+		}
+
+		// create path and map variables
+		String localVarPath = "/modelderivative/v2/designdata/{urn}/metadata/{guid}".replaceAll("\\{format\\}", "json")
+				.replaceAll("\\{" + "urn" + "\\}", apiClient.escapeString(urn.toString()))
+				.replaceAll("\\{" + "guid" + "\\}", apiClient.escapeString(guid.toString()));
+
+		// query params
+		List<Pair> localVarQueryParams = new ArrayList<Pair>();
+		Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+		Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+		if (acceptEncoding != null)
+			localVarHeaderParams.put("Accept-Encoding", apiClient.parameterToString(acceptEncoding));
+
+		final String[] localVarAccepts = { "application/vnd.api+json", "application/json" };
+		final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+		final String[] localVarContentTypes = { "application/json" };
+		final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+		GenericType<Metadata> localVarReturnType = new GenericType<Metadata>() {
+		};
+		return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody,
+				localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
+	}
+
+	/**
    * Returns a list of properties for each object in an object tree. Properties are returned according to object ID and do not follow a hierarchical structure.  The following image displays a typical list of properties for a Revit object:  ![](https://developer.doc.autodesk.com/bPlouYTd/7/_images/Properties.png)  To call this endpoint you need to first call the [GET {urn}/metadata](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-metadata-GET) endpoint, which returns a list of model view (metadata) IDs for a design input model. Select a model view (metadata) ID to use when calling the Get Properties endpoint.  Note that you can only get properties from a design input file that was previously translated into an SVF file. 
    * @param urn The Base64 (URL Safe) encoded design URN  (required)
    * @param guid Unique model view ID. Call [GET {urn}/metadata](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-metadata-GET) to get the ID  (required)
-   * @param acceptEncoding If specified with &#x60;gzip&#x60; or &#x60;*&#x60;, content will be compressed and returned in a GZIP format.  (optional)
-   * @return Metadata
+   * @param acceptEncoding Unique model view ID. Call [GET {urn}/metadata](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-metadata-GET) to get the ID  (required)
+   * @param queryParam Send Json parameters for query URL
+   * @param oauth2
+   * @param credentials
+   * @return
    * @throws ApiException if fails to make API call
+   * @throws Exception
    */
-  public ApiResponse<Metadata> getModelviewProperties(String urn, String guid, String acceptEncoding,  Authentication oauth2, Credentials credentials) throws ApiException, Exception {
+  public ApiResponse<Metadata> getModelviewProperties(String urn, String guid, String acceptEncoding, String queryParam, Authentication oauth2, Credentials credentials) throws ApiException, Exception {
 
     Object localVarPostBody = null;
     
@@ -374,6 +425,10 @@ if (acceptEncoding != null)
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    
+    if (queryParam!=null)
+    	localVarQueryParams.addAll(JacksonMapper.getInstance().toListPair(queryParam));
+    
     Map<String, String> localVarHeaderParams = new HashMap<String, String>();
     Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
@@ -394,93 +449,132 @@ if (acceptEncoding != null)
 
     GenericType<Metadata> localVarReturnType = new GenericType<Metadata>() {};
     return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
-      }
-  /**
-   * 
-   * Returns the thumbnail for the source file. 
-   * @param urn The Base64 (URL Safe) encoded design URN  (required)
-   * @param width The desired width of the thumbnail. Possible values are 100, 200 and 400.  (optional)
-   * @param height The desired height of the thumbnail. Possible values are 100, 200 and 400.  (optional)
-   * @return File
-   * @throws ApiException if fails to make API call
-   */
-  public ApiResponse<File> getThumbnail(String urn, Integer width, Integer height,  Authentication oauth2, Credentials credentials) throws ApiException, Exception {
+  }
 
-    Object localVarPostBody = null;
-    
-    // verify the required parameter 'urn' is set
-    if (urn == null) {
-      throw new ApiException(400, "Missing the required parameter 'urn' when calling getThumbnail");
-    }
-    
-    // create path and map variables
-    String localVarPath = "/modelderivative/v2/designdata/{urn}/thumbnail".replaceAll("\\{format\\}","json")
-      .replaceAll("\\{" + "urn" + "\\}", apiClient.escapeString(urn.toString()));
+	/**
+	 * 
+	 * Returns a list of properties for each object in an object tree. Properties
+	 * are returned according to object ID and do not follow a hierarchical
+	 * structure. The following image displays a typical list of properties for a
+	 * Revit object:
+	 * ![](https://developer.doc.autodesk.com/bPlouYTd/7/_images/Properties.png) To
+	 * call this endpoint you need to first call the [GET
+	 * {urn}/metadata](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-metadata-GET)
+	 * endpoint, which returns a list of model view (metadata) IDs for a design
+	 * input model. Select a model view (metadata) ID to use when calling the Get
+	 * Properties endpoint. Note that you can only get properties from a design
+	 * input file that was previously translated into an SVF file.
+	 * 
+	 * @param urn            The Base64 (URL Safe) encoded design URN (required)
+	 * @param guid           Unique model view ID. Call [GET
+	 *                       {urn}/metadata](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-metadata-GET)
+	 *                       to get the ID (required)
+	 * @param acceptEncoding If specified with &#x60;gzip&#x60; or &#x60;*&#x60;,
+	 *                       content will be compressed and returned in a GZIP
+	 *                       format. (optional)
+	 * @return Metadata
+	 * @throws ApiException if fails to make API call
+	 */
+	@Deprecated
+	public ApiResponse<Metadata> getModelviewProperties(String urn, String guid, String acceptEncoding,
+			Authentication oauth2, Credentials credentials) throws ApiException, Exception {
+		return getModelviewProperties(urn, guid, acceptEncoding, null, oauth2, credentials);
+	}
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+	/**
+	 * 
+	 * Returns the thumbnail for the source file.
+	 * 
+	 * @param urn    The Base64 (URL Safe) encoded design URN (required)
+	 * @param width  The desired width of the thumbnail. Possible values are 100,
+	 *               200 and 400. (optional)
+	 * @param height The desired height of the thumbnail. Possible values are 100,
+	 *               200 and 400. (optional)
+	 * @return File
+	 * @throws ApiException if fails to make API call
+	 */
+	public ApiResponse<File> getThumbnail(String urn, Integer width, Integer height, Authentication oauth2,
+			Credentials credentials) throws ApiException, Exception {
 
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "width", width));
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "height", height));
+		Object localVarPostBody = null;
 
-    
-    
-    final String[] localVarAccepts = {
-      "application/octet-stream"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+		// verify the required parameter 'urn' is set
+		if (urn == null) {
+			throw new ApiException(400, "Missing the required parameter 'urn' when calling getThumbnail");
+		}
 
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+		// create path and map variables
+		String localVarPath = "/modelderivative/v2/designdata/{urn}/thumbnail".replaceAll("\\{format\\}", "json")
+				.replaceAll("\\{" + "urn" + "\\}", apiClient.escapeString(urn.toString()));
 
-    GenericType<File> localVarReturnType = new GenericType<File>() {};
-    return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
-      }
-  /**
-   * 
-   * Translate a source file from one format to another.  Derivatives are stored in a manifest that is updated each time this endpoint is used on a source file.  Note that this endpoint is asynchronous and initiates a process that runs in the background, rather than keeping an open HTTP connection until completion. Use the [GET {urn}/manifest](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-manifest-GET) endpoint to poll for the job’s completion. 
-   * @param job  (required)
-   * @param xAdsForce &#x60;true&#x60;: the endpoint replaces previously translated output file types with the newly generated derivatives  &#x60;false&#x60; (default): previously created derivatives are not replaced  (optional, default to false)
-   * @return Job
-   * @throws ApiException if fails to make API call
-   */
-  public ApiResponse<Job> translate(JobPayload job, Boolean xAdsForce,  Authentication oauth2, Credentials credentials) throws ApiException, Exception {
+		// query params
+		List<Pair> localVarQueryParams = new ArrayList<Pair>();
+		Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+		Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
-    Object localVarPostBody = job;
-    
-    // verify the required parameter 'job' is set
-    if (job == null) {
-      throw new ApiException(400, "Missing the required parameter 'job' when calling translate");
-    }
-    
-    // create path and map variables
-    String localVarPath = "/modelderivative/v2/designdata/job".replaceAll("\\{format\\}","json");
+		localVarQueryParams.addAll(apiClient.parameterToPairs("", "width", width));
+		localVarQueryParams.addAll(apiClient.parameterToPairs("", "height", height));
 
-    // query params
-    List<Pair> localVarQueryParams = new ArrayList<Pair>();
-    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
-    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+		final String[] localVarAccepts = { "application/octet-stream" };
+		final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
 
+		final String[] localVarContentTypes = { "application/json" };
+		final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
-    if (xAdsForce != null)
-      localVarHeaderParams.put("x-ads-force", apiClient.parameterToString(xAdsForce));
+		GenericType<File> localVarReturnType = new GenericType<File>() {
+		};
+		return apiClient.invokeAPI(oauth2, credentials, localVarPath, "GET", localVarQueryParams, localVarPostBody,
+				localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
+	}
 
-    
-    final String[] localVarAccepts = {
-      "application/vnd.api+json", "application/json"
-    };
-    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+	/**
+	 * 
+	 * Translate a source file from one format to another. Derivatives are stored in
+	 * a manifest that is updated each time this endpoint is used on a source file.
+	 * Note that this endpoint is asynchronous and initiates a process that runs in
+	 * the background, rather than keeping an open HTTP connection until completion.
+	 * Use the [GET
+	 * {urn}/manifest](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-manifest-GET)
+	 * endpoint to poll for the job’s completion.
+	 * 
+	 * @param job       (required)
+	 * @param xAdsForce &#x60;true&#x60;: the endpoint replaces previously
+	 *                  translated output file types with the newly generated
+	 *                  derivatives &#x60;false&#x60; (default): previously created
+	 *                  derivatives are not replaced (optional, default to false)
+	 * @return Job
+	 * @throws ApiException if fails to make API call
+	 */
+	public ApiResponse<Job> translate(JobPayload job, Boolean xAdsForce, Authentication oauth2, Credentials credentials)
+			throws ApiException, Exception {
 
-    final String[] localVarContentTypes = {
-      "application/json"
-    };
-    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+		Object localVarPostBody = job;
 
-    GenericType<Job> localVarReturnType = new GenericType<Job>() {};
-    return apiClient.invokeAPI(oauth2, credentials, localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
-      }
+		// verify the required parameter 'job' is set
+		if (job == null) {
+			throw new ApiException(400, "Missing the required parameter 'job' when calling translate");
+		}
+
+		// create path and map variables
+		String localVarPath = "/modelderivative/v2/designdata/job".replaceAll("\\{format\\}", "json");
+
+		// query params
+		List<Pair> localVarQueryParams = new ArrayList<Pair>();
+		Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+		Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+		if (xAdsForce != null)
+			localVarHeaderParams.put("x-ads-force", apiClient.parameterToString(xAdsForce));
+
+		final String[] localVarAccepts = { "application/vnd.api+json", "application/json" };
+		final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+		final String[] localVarContentTypes = { "application/json" };
+		final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+		GenericType<Job> localVarReturnType = new GenericType<Job>() {
+		};
+		return apiClient.invokeAPI(oauth2, credentials, localVarPath, "POST", localVarQueryParams, localVarPostBody,
+				localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarReturnType);
+	}
 }

--- a/src/main/java/com/autodesk/client/auth/OAuth2ThreeLegged.java
+++ b/src/main/java/com/autodesk/client/auth/OAuth2ThreeLegged.java
@@ -310,7 +310,7 @@ public class OAuth2ThreeLegged implements Authentication {
                 jsonObject = (JSONObject) new JSONParser().parse(responseBody);
 
                 String access_token = (String) jsonObject.get("access_token");
-                String refresh_token = (String) jsonObject.get("refresh_token");
+                final String refresh_token = (String) jsonObject.get("refresh_token");
                 // calculate "expires at"
                 long expires_in = (long) jsonObject.get("expires_in");
                 DateTime later = DateTime.now().plusSeconds((int) expires_in);


### PR DESCRIPTION
We encountered a problem in the forge API for Java Ver. 1.0.1.

When submitting the DWFx file to the modelDerivative API and trying to get its properties the system returns the following error -> {"diagnostic": "Please use the 'forceget' parameter to force querying the data."} that 20mb) 

However, the fix refers to a parameter of type QuereParam to be submitted to the API. 
Ex: derivativesApi.getModelviewProperties (base64Urn, guid, "{\" forceget \ ": true}", oauth2TwoLegged, twoLeggedCredentials); 

But the Forge API for Java in version 1.0.1, in the "getModelviewProperties" method, line 376, the List Pair of queryString is instantiated. but in the "getAPIResponse" method, in ApiClient it builds the "forceget" in the URL not as a queryParam but as an ACCEPT Enconding. (as shown in the image).

