### PR TITLE
Fix bug of calling DerivativersApi.getManifest() function error.

### DIFF
--- a/src/main/java/com/autodesk/client/model/ManifestChildren.java
+++ b/src/main/java/com/autodesk/client/model/ManifestChildren.java
@@ -90,7 +90,9 @@ public class ManifestChildren   {
 
     AEC_MODELDATA("Autodesk.AEC.ModelData"),
 
-    OBJ("obj");
+    OBJ("obj"),
+
+    ORIGINAL_THUMBNAIL("original-thumbnail");
 
     private String value;
 


### PR DESCRIPTION
Fix when calling DerivativersApi.getManifest(), the "original-thumbnail" is not found and the JSON parsing fails. 